### PR TITLE
Add support for building spack virtual environments before launching job

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -87,7 +87,9 @@ disable=raw-checker-failed,
         deprecated-pragma,
         use-symbolic-message-instead,
         R0912,
-        R0915
+        R0914,
+        R0915,
+
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/rec/__main__.py
+++ b/rec/__main__.py
@@ -1,4 +1,3 @@
-#!/bin/python3
 """
 REC - Runtime Environment Capture
 Maintained by Carson Woods
@@ -12,6 +11,7 @@ import json
 import sys
 from datetime import datetime
 from hashlib import sha256
+import logging
 
 from rec.lib.launcher import Launcher
 from rec.lib.environment import Environment
@@ -34,17 +34,33 @@ def parse_arguments():
                         dest='verbose_version',
                         action='store_true',
                         help='captures full output of --version command'
-                             'rather than just the first line')
+                             ' rather than just the first line')
 
     parser.add_argument('-l', '--launcher',
                         action='store',
                         default='cli',
-                        help='sets runtime launcher for script'
-                             ' [slurm, sge, bash, shell, cli]')
+                        choices=['cli', 'shell', 'bash', 'slurm', 'sge'],
+                        help='sets runtime launcher for script')
 
     parser.add_argument('-n', '--name',
                         action='store',
                         help='sets job name')
+
+    parser.add_argument('-d', '--debug',
+                        action='store_true',
+                        help='enables additional logging')
+
+    parser.add_argument('--env-type',
+                        dest='env_type',
+                        choices=['spack'],
+                        help='specify an environment type'
+                             ' also requires the --env-file flag')
+
+    parser.add_argument('--env-file',
+                        dest='env_file',
+                        action='store',
+                        help='specify an environment file path'
+                             ' also requires the --env-type flag')
 
     parser.add_argument('script',
                         nargs='*',
@@ -87,6 +103,26 @@ def main():
     """
     arguments = parse_arguments()
 
+    # Set logging level
+    if arguments.debug:
+        logging.basicConfig(format='%(message)s',
+                            level=logging.DEBUG)
+
+    # ensures that both environment
+    # flags are specified if one flag is
+    if arguments.env_type is not None:
+        if arguments.env_file is None:
+            print("If specifying a environment type,"
+                  " you must specify an environment file"
+                  " using the `--env-file` flag.")
+            sys.exit()
+    if arguments.env_file is not None:
+        if arguments.env_type is None:
+            print("If specifying a environment file,"
+                  " you must specify an environment type"
+                  " using the `--env-type` flag.")
+            sys.exit()
+
     # Store reproducibility results as json object
     results = {}
 
@@ -95,14 +131,24 @@ def main():
 
     # record results
     if arguments.name:
-        results['name'] = arguments.name + ".out"
+        results['name'] = arguments.name
     else:
-        results['name'] = 'rec-' + datetime.now().strftime("%H-%M-%S") + ".out"
+        results['name'] = 'rec-' + datetime.now().strftime("%H-%M-%S")
 
     # initialize environment
-    results['hostname'] = Environment().hostname
-    results['architecture'] = Environment().architecture
-    results['environment'] = Environment().environment
+    env = Environment(name=results['name'],
+                      env_type=arguments.env_type,
+                      env_file=arguments.env_file)
+    results['hostname'] = env.hostname
+    results['architecture'] = env.architecture
+    results['environment'] = env.environment
+
+    # collect information about the environment
+    if arguments.env_type is not None:
+        results['env_type'] = arguments.env_type
+        with open(arguments.env_file, 'r', encoding="utf-8") as file:
+            results['env_file'] = file.read()
+        results['env_setup_log'] = env.env_install_log
 
     # initialize launcher
     launcher = Launcher(arguments.launcher)
@@ -114,7 +160,6 @@ def main():
 
     # hashes input (script or file)
     if arguments.launcher == 'cli':
-
         # gets hash of CLI input to REC
         to_encode = "".join(arguments.script)
         results['hash'] = sha256(to_encode.encode('ascii')).hexdigest()
@@ -170,7 +215,7 @@ def main():
 
     results['script_output'] = script_result.stdout.decode('utf-8')
 
-    with open(results['name'], 'w', encoding="utf-8") as file:
+    with open(results['name']+'.out', 'w', encoding="utf-8") as file:
         json.dump(results, file, indent=4)
 
 

--- a/rec/lib/environment.py
+++ b/rec/lib/environment.py
@@ -5,7 +5,9 @@ Copyright 2020-2022
 """
 
 import os
+import sys
 import subprocess
+from logging import debug
 
 
 class Environment():
@@ -14,12 +16,57 @@ class Environment():
     as an object.
     """
 
-    def __init__(self):
+    def __init__(self, name, env_type=None, env_file=None):
 
+        self.name = name
         self.environment = dict(os.environ)
         self.architecture = self.get_arch()
         self.hostname = self.get_hostname()
 
+        self.env_type = env_type
+        self.env_file = env_file
+        self.env_install_log = None
+        self.setup_env()
+
+    def setup_env(self):
+        """
+        Constructs virtual environment if specified
+
+        Currently supported environment types:
+        None, Spack
+        """
+        if self.env_type == 'spack':
+            # creates a Spack virtual environment
+            cmd_create = 'spack env create ' + self.name
+            cmd_create = cmd_create + " " + self.env_file
+            out = subprocess.run(cmd_create,
+                                 capture_output=True,
+                                 check=True,
+                                 shell=True).stdout.decode('utf-8')
+
+            if "Created environment" in out:
+                out = out.split('\n')[1].split(' ')[-1]
+                self.environment['SPACK_ENV'] = out
+                debug("Environment created successfully")
+
+                debug("Installing " + self.name + " environment")
+
+                # constructs complex command to add Spack to environment
+                # activate previously created environment
+                # and install the environment
+                cmd_install = ". " + os.environ['SPACK_ROOT']
+                cmd_install = cmd_install + '/share/spack/setup-env.sh;'
+                cmd_install = cmd_install + 'spack env activate ' + self.name
+                cmd_install = cmd_install + "; spack install"
+                out = subprocess.run(cmd_install,
+                                     capture_output=True,
+                                     check=True,
+                                     shell=True).stdout.decode('utf-8')
+                self.env_install_log = out
+                debug("Environment " + self.name + " installed")
+            else:
+                del out
+                sys.exit("Environment could not be created")
 
     def get_arch(self):
         """
@@ -29,7 +76,6 @@ class Environment():
                                            capture_output=True,
                                            check=True)
         return self.architecture.stdout.decode('utf-8').strip()
-
 
     def get_hostname(self):
         """

--- a/rec/lib/environment.py
+++ b/rec/lib/environment.py
@@ -47,6 +47,7 @@ class Environment():
             if "Created environment" in out:
                 out = out.split('\n')[1].split(' ')[-1]
                 self.environment['SPACK_ENV'] = out
+                self.environment['REC_ENV'] = self.name
                 debug("Environment created successfully")
 
                 debug("Installing " + self.name + " environment")


### PR DESCRIPTION
This PR adds support for REC constructing a virtual Spack environment prior to the construction. This PR adds the following flags `--env-type` and `--end-file`. If both are specified, the user could run rec like as follows:
```shell
rec --name test --env-type spack --env-file spack.yaml echo "Hello"
```

Both flags must be specified. Currently, the need to specify the env-type is a bit redundant, however, eventually, new environment types will/can be added. Importantly, this does NOT ensure that the environment is built correctly, but it can be used to automate reproducibility. This PR also injects a `REC_ENV` environment variable that scripts can take advantage of. The name of the environment is set by the `-n/--name` flag and this sets the environment name. If the name is generated dynamically, the environment variable can be used by scripts to activate the environment. 

Other features:
As a result of developing this PR, logging and debugging has been added through the `-d/--debug` flag. 